### PR TITLE
Upgrade versions, expand on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ See the [Platform Tooling](https://s3-us-west-2.amazonaws.com/rp-tooling-temp-do
 
 ## Deploying to Minikube
 
+There's two ways you can deploy to Minikube. There's a manual process which matches what you would typically do in
+a production environment, that is generating resources using `rp` and piping those to `kubectl`.
+
+The SBT task, `deploy minikube`, automates this for you for local development.
+
+Both are documented below.
+
+### Using SBT deploy minikube (Developer workflow)
+
+Use the SBT task to deploy the application. This will build and deploy both applications to your Minikube. Three
+instances of `clustered-impl` will be started (see build.sbt for this configuration).
+
+```bash
+sbt 'deploy minikube'
+```
+
+> You can also run this task directly from within SBT.
+
+### Using command line (Operations workflow)
+
 Setup Minikube Docker environment variables.
 
 ```bash
@@ -52,7 +72,7 @@ $ rp generate-kubernetes-deployment hello-reactive-tooling/simple-impl:0.0.1 --g
 Similarly, deploy the `clustered-impl`. We also won't expose `clustered-impl` outside of Kubernetes. We also scale the `clustered-impl` to `3` instances to test the cluster functionality.
 
 ```bash
-$ rp generate-kubernetes-deployment hello-reactive-tooling/clustered-impl:0.0.1 --generate-services --generate-pod-controllers --pod-controller-replicas 3 --env JAVA_OPTS="-Dplay.http.secret.key=clustered" --external-service simple-service=_lagom-http-api._tcp.simple-service.default.svc.cluster.local | kubectl apply -f -
+$ rp generate-kubernetes-deployment hello-reactive-tooling/clustered-impl:0.0.1 --generate-services --generate-pod-controllers --pod-controller-replicas 3 --env JAVA_OPTS="-Dplay.http.secret.key=clustered" | kubectl apply -f -
 ```
 
 
@@ -116,7 +136,7 @@ $ curl -vLk "https://$(minikube ip)/srv/<service-name>"
 Example:
 
 ```bash
-$ curl -vLk "https://$(minikube ip)/srv/_cql._tcp.cassandra-cassandra.cassandra.svc.cluster.local"
+$ curl -vLk "https://$(minikube ip)/srv/_http._tcp.simple-service.default.svc.cluster.local"
 ```
 
 Run the following command, replacing `<service-name>` with the actual service name and `<endpoint-name>` with the actual endpoint name. This command will return a list of address for a given service name and endpoint name.
@@ -128,5 +148,5 @@ $ curl -vLk "https://$(minikube ip)/srv/<service-name>/<endpoint-name>"
 Example:
 
 ```bash
-$ curl -vLk "https://$(minikube ip)/srv/simple-service/lagom-http-api"
+$ curl -vLk "https://$(minikube ip)/srv/simple-service/http-api"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 organization in ThisBuild := "com.lightbend"
 version in ThisBuild := "0.0.1"
 
+
 // the Scala version that will be used for cross-compiled libraries
 scalaVersion in ThisBuild := "2.11.8"
 
@@ -23,7 +24,8 @@ lazy val frontend = (project in file("frontend"))
     libraryDependencies ++= Seq(
       guice, // This is required to configure Play's application loader
       ws
-    )
+    ),
+    httpIngressPaths := Seq("/")
   )
 
 lazy val `simple-api` = (project in file("simple-api"))
@@ -49,9 +51,13 @@ lazy val `clustered-impl` = (project in file("clustered-impl"))
     libraryDependencies ++= {
       Seq(
         lagomScaladslCluster,
+        "com.typesafe.akka" %% "akka-cluster-sharding" % "2.5.6",
         "com.typesafe.akka" %% "akka-distributed-data" % "2.5.6",
         "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
-      )
-    }
+      ),
+    },
+
+    // For sbt 'deploy minikube', use 3 replicas
+    deployMinikubeAkkaClusterBootstrapContactPoints := 3
   )
   .dependsOn(`clustered-api`, `simple-api`)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.16
+sbt.version=1.1.1
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % "0.4.4")
+addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % "0.6.1")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.7")
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0-M3")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")


### PR DESCRIPTION
* sbt 1.1.1
* sbt-reactive-app `0.6.1` (to be published today, see https://github.com/lightbend/sbt-reactive-app/pull/87)
* Add `sbt 'deploy minikube'` command.
* Various fixes to README as tooling has changed